### PR TITLE
fix: use filtered count for pagination instead of hardcoded value (#1)

### DIFF
--- a/pages/collections/[collectionId]/nfts-ssr.tsx
+++ b/pages/collections/[collectionId]/nfts-ssr.tsx
@@ -49,6 +49,7 @@ type NftsProps = {
   collectionId: string,
   rarities?: { [key: string]: { [key: string]: number } },
   total: number,
+  filtered: number,
   nfts: RankedNft[],
   filter: SearchFilter,
   select: FieldSelect,
@@ -75,7 +76,7 @@ const getSearchParams = (searchParams: SearchParams): string => {
 };
 
 const NftsSsr: FunctionComponent<NftsProps> = (props) => {
-  const {name, bannerUrl, collectionId, rarities, filter, select, nfts, total} = props;
+  const {name, bannerUrl, collectionId, rarities, filter, select, nfts, total, filtered} = props;
 
   const router = useRouter();
   const imageContainer = useRef(null);
@@ -324,7 +325,7 @@ const NftsSsr: FunctionComponent<NftsProps> = (props) => {
           </div>
           <div style={{display: 'flex', width: '100%', justifyContent: 'start'}}>
             <Pagination
-              count={Math.ceil(1000 / (cardCount * ROW_COUNT))} //TODO
+              count={Math.ceil(filtered / (cardCount * ROW_COUNT)) || 1}
               onChange={handleOnPage}
               page={filter['page'] ? Number(filter['page']) : 1}
             />
@@ -368,6 +369,7 @@ export async function getServerSideProps({res, query}: ServerSideProps) {
     select,
     nfts: [],
     total: 0,
+    filtered: 0,
     collectionId: collectionId as string,
   };
 
@@ -443,7 +445,7 @@ export async function getServerSideProps({res, query}: ServerSideProps) {
   );
 
   if (nftData && nftData.items.length > 0) {
-    const {items, total} = nftData;
+    const {items, total, filtered} = nftData;
 
     // _id cannot be serialized
     items.forEach((item: any) => {
@@ -453,6 +455,7 @@ export async function getServerSideProps({res, query}: ServerSideProps) {
     props = {
       ...props,
       total,
+      filtered,
       nfts: (items as RankedNft[]) || [],
     };
   }

--- a/types/api/RankedNftDocuments.ts
+++ b/types/api/RankedNftDocuments.ts
@@ -2,5 +2,6 @@ import {RankedNft} from '../RankedNft';
 
 export type RankedNftDocuments = {
   total: number,
+  filtered: number,
   items: RankedNft[]
 }


### PR DESCRIPTION
## Summary

Fixes the pagination bug on the NFT collection listing page. The pagination component was using a hardcoded value of 1000 for the page count instead of the actual filtered result count returned by the API.

## Changes

- **Add `filtered` field to `NftsProps` type** — the component now receives the filtered count from the API
- **Add `filtered` field to `RankedNftDocuments` type** — ensures TypeScript type consistency
- **Pass filtered count through server-side props** — the `getOrCreateNfts` API already returns `filtered` (the count of NFTs matching the current filters), but it was being ignored
- **Use `filtered` in Pagination component** — replaced the hardcoded `1000` with the actual filtered count
- **Default `filtered` to 0** — handles the case where no data is available

## Test Plan

- [ ] Verify pagination shows correct number of pages for filtered results
- [ ] Verify pagination works correctly when no filters are applied
- [ ] Verify pagination handles edge case of zero results

Closes #1